### PR TITLE
style(mobilequery): Allow for phone/tablet/desktop layouts

### DIFF
--- a/src/app/mobile-query.service.ts
+++ b/src/app/mobile-query.service.ts
@@ -18,37 +18,51 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Injectable } from '@angular/core';
-import { MediaMatcher } from '@angular/cdk/layout';
+import { BreakpointObserver, MediaMatcher } from '@angular/cdk/layout';
 import { Subject } from 'rxjs';
 
-// just an injectable wrapper around a preconfigured MediaMatcher
+export enum ScreenSize {
+    Phone,
+    Tablet,
+    Desktop,
+}
 
 @Injectable()
 export class MobileQueryService {
-    public mobileQuery: MediaQueryList;
-    public changed = new Subject<boolean>();
+    screenSize: ScreenSize;
+    screenSizeChanged = new Subject<ScreenSize>();
+
+    // deprecated, use ScreenSize instead
+    private mobileQuery: MediaQueryList;
+
+    changed = new Subject<boolean>();
 
     get matches(): boolean {
         return this.mobileQuery.matches;
     }
 
     constructor(
-        media: MediaMatcher,
+        breakpointObserver: BreakpointObserver,
+        media:              MediaMatcher,
     ) {
+        breakpointObserver.observe([
+            // I'm not sure if passing raw selectors is even the allowed API here,
+            // but the docs do say `string`, so eh
+            '(max-width: 480px)',
+            '(max-width: 1024px)',
+        ]).subscribe(_ => {
+            if (window.innerWidth <= 480) {
+                this.screenSize = ScreenSize.Phone;
+            } else if (window.innerWidth <= 1024) {
+                this.screenSize = ScreenSize.Tablet;
+            } else {
+                this.screenSize = ScreenSize.Desktop;
+            }
+            this.screenSizeChanged.next(this.screenSize);
+        });
+
         this.mobileQuery = media.matchMedia('(max-width: 1024px)');
         // tslint:disable-next-line:deprecation
         this.mobileQuery.addListener(() => this.changed.next(this.mobileQuery.matches));
-    }
-
-    addListener(listener: () => void) {
-        // the non-deprecated addEventListener doesn't work on Safari, so...
-        // tslint:disable-next-line:deprecation
-        this.mobileQuery.addListener(listener);
-    }
-
-    removeListener(listener: () => void) {
-        // the non-deprecated removeEventListener doesn't work on Safari, so...
-        // tslint:disable-next-line:deprecation
-        this.mobileQuery.removeListener(listener);
     }
 }

--- a/src/app/mobile-query.service.ts
+++ b/src/app/mobile-query.service.ts
@@ -18,7 +18,7 @@
 // ---------- END RUNBOX LICENSE ----------
 
 import { Injectable } from '@angular/core';
-import { BreakpointObserver, MediaMatcher } from '@angular/cdk/layout';
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { Subject } from 'rxjs';
 
 export enum ScreenSize {
@@ -32,18 +32,13 @@ export class MobileQueryService {
     screenSize: ScreenSize;
     screenSizeChanged = new Subject<ScreenSize>();
 
-    // deprecated, use ScreenSize instead
-    private mobileQuery: MediaQueryList;
-
+    // old API, meaning "is it not a desktop"
+    // use screenSize instead
+    matches: boolean;
     changed = new Subject<boolean>();
-
-    get matches(): boolean {
-        return this.mobileQuery.matches;
-    }
 
     constructor(
         breakpointObserver: BreakpointObserver,
-        media:              MediaMatcher,
     ) {
         breakpointObserver.observe([
             // I'm not sure if passing raw selectors is even the allowed API here,
@@ -59,10 +54,13 @@ export class MobileQueryService {
                 this.screenSize = ScreenSize.Desktop;
             }
             this.screenSizeChanged.next(this.screenSize);
-        });
 
-        this.mobileQuery = media.matchMedia('(max-width: 1024px)');
-        // tslint:disable-next-line:deprecation
-        this.mobileQuery.addListener(() => this.changed.next(this.mobileQuery.matches));
+            // old API compatibility
+            const matches = this.screenSize !== ScreenSize.Desktop;
+            if (matches !== this.matches) {
+                this.matches = matches;
+                this.changed.next(matches);
+            }
+        });
     }
 }

--- a/src/app/profiles/profiles.lister.ts
+++ b/src/app/profiles/profiles.lister.ts
@@ -22,35 +22,29 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ProfilesEditorModalComponent } from './profiles.editor.modal';
 import { RMM } from '../rmm';
+import { MobileQueryService, ScreenSize } from '../mobile-query.service';
 
 @Component({
     selector: 'app-profiles-lister',
     styleUrls: ['profiles.lister.scss'],
     templateUrl: 'profiles.lister.html',
-    host: {
-        '(window:resize)': 'onResize($event)',
-    },
 })
 export class ProfilesListerComponent {
     @Input() values: any[];
     @Output() ev_reload = new EventEmitter<string>();
 
     private dialog_ref: any;
+    mobile: boolean;
+
     constructor(
         public dialog: MatDialog,
         public rmm: RMM,
-        public snackBar: MatSnackBar
+        public snackBar: MatSnackBar,
+        mobileQuery: MobileQueryService,
     ) {
         this.rmm.me.load();
-    }
-
-    mobile;
-
-    ngOnInit() {
-        this.mobile = window.innerWidth <= 480 ? true : false;
-    }
-    onResize(event) {
-        this.mobile = event.target.innerWidth <= 480 ? true : false;
+        this.mobile = mobileQuery.screenSize === ScreenSize.Phone;
+        mobileQuery.screenSizeChanged.subscribe(size => this.mobile = size === ScreenSize.Phone);
     }
 
     edit(item): void {


### PR DESCRIPTION
It maintains backwards compatibility by treating everything non-desktop
as a mobile, but allows being more specific in future components that
need a more fine-grained detection.